### PR TITLE
Add no-op on less prices for prices register code

### DIFF
--- a/server/src/models/prices.rs
+++ b/server/src/models/prices.rs
@@ -2,6 +2,7 @@ use crate::models::assets::{register_etf_asset, register_treasury_asset};
 use crate::schema::asset_prices;
 use bigdecimal::{BigDecimal, Zero};
 use chrono::NaiveDate;
+use diesel::dsl::count_star;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 
@@ -16,7 +17,17 @@ fn replace_asset_prices(
     conn: &PgConnection,
     asset_id: i32,
     prices: Vec<(NaiveDate, BigDecimal)>,
-) -> QueryResult<()> {
+) -> QueryResult<usize> {
+    let prev_prices_count: i64 = asset_prices::table
+        .select(count_star())
+        .filter(asset_prices::asset_id.eq(asset_id))
+        .get_result(conn)?;
+
+    let new_prices_count = prices.len() as i64 - prev_prices_count;
+    if new_prices_count <= 0 {
+        return Ok(0);
+    }
+
     diesel::delete(asset_prices::table.filter(asset_prices::asset_id.eq(asset_id)))
         .execute(conn)?;
 
@@ -33,18 +44,17 @@ fn replace_asset_prices(
         .values(insertable_prices)
         .execute(conn)?;
 
-    Ok(())
+    Ok(new_prices_count as usize)
 }
 
 pub fn register_treasury_prices(
     conn: &PgConnection,
     maturity_date: NaiveDate,
     prices: Vec<(NaiveDate, BigDecimal)>,
-) -> QueryResult<()> {
+) -> QueryResult<usize> {
     conn.transaction(|| {
         let asset_id = register_treasury_asset(conn, maturity_date)?;
-        replace_asset_prices(conn, asset_id, prices)?;
-        Ok(())
+        replace_asset_prices(conn, asset_id, prices)
     })
 }
 
@@ -52,11 +62,10 @@ pub fn register_etf_prices(
     conn: &PgConnection,
     ticker: &str,
     prices: Vec<(NaiveDate, BigDecimal)>,
-) -> QueryResult<()> {
+) -> QueryResult<usize> {
     conn.transaction(|| {
         let asset_id = register_etf_asset(conn, ticker)?;
-        replace_asset_prices(conn, asset_id, prices)?;
-        Ok(())
+        replace_asset_prices(conn, asset_id, prices)
     })
 }
 

--- a/server/src/routes/import_etfs_prices.rs
+++ b/server/src/routes/import_etfs_prices.rs
@@ -13,7 +13,7 @@ pub async fn post(db: Data<Database>) -> HttpResponse {
             (
                 ticker,
                 match result {
-                    Ok(()) => Ok(()),
+                    Ok(new_prices_count) => Ok(new_prices_count),
                     Err(import_etfs_prices::Error::Network(_)) => Err("Network"),
                     Err(import_etfs_prices::Error::Status(_)) => Err("Status"),
                     Err(import_etfs_prices::Error::Payload(_)) => Err("Payload"),

--- a/server/src/services/import_etfs_prices.rs
+++ b/server/src/services/import_etfs_prices.rs
@@ -115,11 +115,11 @@ fn write(
     conn: &PgConnection,
     ticker: &str,
     lines: Vec<(NaiveDate, BigDecimal)>,
-) -> Result<(), Error> {
+) -> Result<usize, Error> {
     register_etf_prices(conn, ticker, lines).map_err(Error::Writing)
 }
 
-pub async fn run(conn: &PgConnection) -> Vec<(&'static str, Result<(), Error>)> {
+pub async fn run(conn: &PgConnection) -> Vec<(&'static str, Result<usize, Error>)> {
     let tickers_params = [
         ("BOVA11", BOVA11_FORM_PARAMS),
         ("SMAL11", SMAL11_FORM_PARAMS),


### PR DESCRIPTION
The idea here is simple: if the system is trying to replace N prices
by M prices where M is less than N, it does nothing. The idea is to
preserve the biggest count of prices we can.

Closes #26.